### PR TITLE
Switched karlsen testnet port to '42210'

### DIFF
--- a/wallet/wallet.ts
+++ b/wallet/wallet.ts
@@ -140,7 +140,7 @@ class Wallet extends EventTargetImpl {
 	/**
 	 * Current API endpoint for selected network
 	 */
-	apiEndpoint = 'localhost:16210';
+	apiEndpoint = 'localhost:42210';
 
 	/**
 	 * A 12 word mnemonic.


### PR DESCRIPTION
Simple pull request to switch testnet port to `42210`. It was forgotten during fork but is needed for upcoming public testnet.